### PR TITLE
Use response.json() when sending JSON data

### DIFF
--- a/controllers/notes.js
+++ b/controllers/notes.js
@@ -31,7 +31,7 @@ notesRouter.get('/:id', async (request, response) => {
 
   } catch (exception) {
     console.log(exception)
-    response.status(400).send({ error: 'malformatted id' })
+    response.status(400).json({ error: 'malformatted id' })
   }
 })
 
@@ -42,7 +42,7 @@ notesRouter.delete('/:id', async (request, response) => {
     response.status(204).end()
   } catch (exception) {
     console.log(exception)
-    response.status(400).send({ error: 'malformatted id' })
+    response.status(400).json({ error: 'malformatted id' })
   }
 })
 
@@ -101,7 +101,7 @@ notesRouter.put('/:id', (request, response) => {
     })
     .catch(error => {
       console.log(error)
-      response.status(400).send({ error: 'malformatted id' })
+      response.status(400).json({ error: 'malformatted id' })
     })
 })
 


### PR DESCRIPTION
Change from `response.send()` to `response.json()` because:
- [Send-method in Express defaults the content type to "html" when using a string](https://github.com/expressjs/express/blob/master/lib/response.js#L142).
- Using both methods in code without further explanation is rather confusing.
